### PR TITLE
deb: delete key from trusted.gpg

### DIFF
--- a/deb/brave-keyring/DEBIAN/postinst
+++ b/deb/brave-keyring/DEBIAN/postinst
@@ -2,3 +2,6 @@
 
 chown root:root /etc/apt/trusted.gpg.d/brave-browser-release.gpg
 chmod 0644 /etc/apt/trusted.gpg.d/brave-browser-release.gpg
+
+# Delete (expired) key added by old install instructions
+apt-key --keyring /etc/apt/trusted.gpg del D8BAD4DE7EE17AF52A834B2D0BB75829C2D4E821


### PR DESCRIPTION
This commit deletes the GPG key that was added by our users in older
versions of the installation instructions. Although the signature is
the same as the new unexpired key, only the expired key will be deleted
due to the --keyring option passed.

Fixes: brave/brave-browser#4097