### PR TITLE
deb: bump keyring package to 1.2 for old key removal

### DIFF
--- a/deb/brave-keyring/DEBIAN/control
+++ b/deb/brave-keyring/DEBIAN/control
@@ -2,5 +2,5 @@ Package: brave-keyring
 Architecture: all
 Maintainer: Ben Kero <bkero@brave.com>
 Priority: optional
-Version: 1.1
+Version: 1.2
 Description: Brave Browser keyring and repository files


### PR DESCRIPTION
This commit bumps the keyring package version number so that we can push out a postinst fix to delete some older keys.