### PR TITLE
Enable user namespaces

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -1,4 +1,5 @@
 all:
+	mkdir -p output
 	sh make-keyring.sh
 	sh make-dists.sh
 

--- a/deb/brave-keyring/DEBIAN/control
+++ b/deb/brave-keyring/DEBIAN/control
@@ -2,6 +2,6 @@ Package: brave-keyring
 Architecture: all
 Maintainer: Ben Kero <bkero@brave.com>
 Priority: optional
-Version: 1.3
+Version: 1.4
 Description: Brave Browser keyring and repository files
 Depends: gnupg

--- a/deb/brave-keyring/DEBIAN/postinst
+++ b/deb/brave-keyring/DEBIAN/postinst
@@ -5,3 +5,6 @@ chmod 0644 /etc/apt/trusted.gpg.d/brave-browser-release.gpg
 
 # Delete (expired) key added by old install instructions
 apt-key --keyring /etc/apt/trusted.gpg del D8BAD4DE7EE17AF52A834B2D0BB75829C2D4E821
+
+# Enable user namespaces immediately
+sysctl -p /etc/sysctl.d/brave.conf

--- a/deb/brave-keyring/etc/sysctl.d/brave.conf
+++ b/deb/brave-keyring/etc/sysctl.d/brave.conf
@@ -1,0 +1,3 @@
+# Enable user namespaces which are required by the Chromium sandbox
+# https://github.com/brave/brave-browser/issues/1986#issuecomment-445057361
+kernel.unprivileged_userns_clone = 1

--- a/deb/make-keyring.sh
+++ b/deb/make-keyring.sh
@@ -11,4 +11,4 @@ wget https://brave-browser-apt-release.s3.brave.com/brave-core.asc
 
 gpg --no-default-keyring --keyring ./tmp.gpg --import brave-core.asc
 gpg --no-default-keyring --keyring ./tmp.gpg --export > "${BASE}/etc/apt/trusted.gpg.d/brave-browser-release.gpg"
-rm -f tmp.gpg brave-core.asc brave-core-nightly.asc "${BASE}/etc/apt/trusted.gpg.d/brave-browser-release.gpg~"
+rm -f tmp.gpg~ tmp.gpg brave-core.asc brave-core-nightly.asc "${BASE}/etc/apt/trusted.gpg.d/brave-browser-release.gpg~"


### PR DESCRIPTION
Fixes brave/brave-browser#5502.

Tested on Debian:

1. Ensure that user namespaces are disabled:
```
$ sysctl kernel.unprivileged_userns_clone
kernel.unprivileged_userns_clone = 0
```
2. Install the `brave-browser` package using the [official instructions](https://brave-browser.readthedocs.io/en/latest/installing-brave.html#linux).
3. Confirm that Brave crashes on startup.
4. Install the updated `brave-keyring` package (version 1.4).
5. Confirm that Brave starts up fine.