### PR TITLE
Tell sysctl postinst to ignore errors

### DIFF
--- a/deb/brave-keyring/DEBIAN/postinst
+++ b/deb/brave-keyring/DEBIAN/postinst
@@ -7,4 +7,4 @@ chmod 0644 /etc/apt/trusted.gpg.d/brave-browser-release.gpg
 apt-key --keyring /etc/apt/trusted.gpg del D8BAD4DE7EE17AF52A834B2D0BB75829C2D4E821
 
 # Enable user namespaces immediately if they're available
-sysctl -p /etc/sysctl.d/brave.conf || true
+sysctl -e -p /etc/sysctl.d/brave.conf


### PR DESCRIPTION
Modifies the postinst script in the deb with the -e option, which
ignores errors for missing keys