### PR TITLE
Silence grep to prevent unnecessary cron.daily emails

### DIFF
--- a/rpm/brave-keyring-1.5/etc/cron.daily/brave-key-updater
+++ b/rpm/brave-keyring-1.5/etc/cron.daily/brave-key-updater
@@ -3,7 +3,7 @@
 CURRENT_KEY="gpg-pubkey-c2d4e821-5d13a788"
 OLD_KEYS="gpg-pubkey-c2d4e821-5bc51032 gpg-pubkey-c2d4e821-5cae3514"
 for key in $CURRENT_KEY $OLD_KEYS; do
-    if rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep "$key"; then
+    if rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep -q "$key"; then
         rpm -e "$key" # Remove expiring key
     fi
 done


### PR DESCRIPTION
Without the `-q` the cronjob would print to `stdout` and possibly send an email about this, every day. Btw, why is the `CURRENT_KEY` removed as well - and then imported again in the same script?

```
Date: Tue, 10 Dec 2019 19:19:01
From: root <root@localhost>
To: root@example.com
Subject: Anacron job 'cron.daily' on host

/etc/cron.daily/brave-key-updater:
gpg-pubkey-c2d4e821-5d13a788    Brave Software <support@brave.com> public key
```