### PR TITLE
Fix regression with kernel.unprivileged_userns_clone

### DIFF
--- a/deb/brave-keyring/DEBIAN/postinst
+++ b/deb/brave-keyring/DEBIAN/postinst
@@ -4,4 +4,4 @@
 apt-key --keyring /etc/apt/trusted.gpg del D8BAD4DE7EE17AF52A834B2D0BB75829C2D4E821
 
 # Enable user namespaces immediately if they're available
-sysctl -e -p /etc/sysctl.d/30-brave.conf
+sysctl -p /etc/sysctl.d/30-brave.conf || true


### PR DESCRIPTION
Installation of `brave-browser==1.1.22` with `brave-keyring==1.7` fails if installed on a Debian 10 inside a Docker container or similar already sandboxed environment. This is a regression, with `brave-keyring==1.5` this used to work!

**Details**: The post-installation script for `brave-keyring` attempts to enable user namespaces in the kernel, but in an already sandboxed environment it is not allowed to do that.

```sh
$ apt-get install brave-browser
...
Selecting previously unselected package brave-keyring.
Preparing to unpack .../4-brave-keyring_1.7_all.deb ...
Unpacking brave-keyring (1.7) ...
Selecting previously unselected package brave-browser.
Preparing to unpack .../5-brave-browser_1.1.22_amd64.deb ...
Unpacking brave-browser (1.1.22) ...
...
Setting up brave-keyring (1.7) ...
OK
sysctl: setting key "kernel.unprivileged_userns_clone": Read-only file system
dpkg: error processing package brave-keyring (--configure):
 installed brave-keyring package post-installation script subprocess returned error exit status 255
...
Errors were encountered while processing:
 brave-keyring
 brave-browser
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

**Expected**: Instead of preventing the installation it should fail gracefully and allow the installation to finish and let the user manually handle the sandboxing. There were no issues running the older version of Brave browser with `--no-sandbox` inside a Docker container (except the annoying message that security might be degraded).

**Pull request**: This pull request reverts the problematic commit 74e978789b086bf38a69330c51fdfc72fe4a2ccd. The `sysctl -e` is only useful for ignoring errors about unknown keys, not read-only keys. Therefore a `|| true` is necessary.

**Problematic version**: `brave-browser==1.1.22`, `brave-keyring==1.7`, on Debian 10

Issues related to user namespaces: https://github.com/brave/brave-browser/issues/5502, https://github.com/brave/brave-browser/issues/6247