### PR TITLE
Made brave-keyring depend on at.

### DIFF
--- a/rpm/brave-keyring.spec
+++ b/rpm/brave-keyring.spec
@@ -8,6 +8,8 @@ URL:        https://www.brave.com/
 Source0:    ./brave-keyring-source.tar.gz
 BuildArch:  noarch
 
+Requires:   at
+
 %description
 The Brave keyring setup installs the keyring files necessary for validating
 packages. In the future it will install the yum.repos.d repository for for


### PR DESCRIPTION
Closes brave/brave-browser#8751

Ran `make -C rpm` to build the package.

Verified with:
```console
% docker run --rm -it -v $PWD/rpm/output/brave-keyring-1.8-1.noarch.rpm:/tmp/bk.rpm fedora rpm -qR /tmp/bk.rpm
/bin/sh
/usr/bin/sh
at
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
%
```