### PR TITLE
Update and rename 50-brave.conf to 53-brave.conf (rpm)

### DIFF
--- a/rpm/brave-keyring-1.12/usr/lib/sysctl.d/53-brave.conf
+++ b/rpm/brave-keyring-1.12/usr/lib/sysctl.d/53-brave.conf
@@ -1,3 +1,2 @@
 # Recommended kernel settings for the Chromium sandbox (see chrome://sandbox)
-#kernel.unprivileged_userns_clone = 1
 #kernel.yama.ptrace_scope = 1

--- a/rpm/brave-keyring.spec
+++ b/rpm/brave-keyring.spec
@@ -30,7 +30,7 @@ install -m 644 etc/pki/rpm-gpg/RPM-GPG-KEY-brave -t %{buildroot}/etc/pki/rpm-gpg
 install -m 644 etc/pki/rpm-gpg/RPM-GPG-KEY-brave-beta -t %{buildroot}/etc/pki/rpm-gpg/
 install -m 644 etc/pki/rpm-gpg/RPM-GPG-KEY-brave-nightly -t %{buildroot}/etc/pki/rpm-gpg/
 install -m 755 etc/cron.daily/brave-key-updater -t %{buildroot}/etc/cron.daily/
-install -m 644 usr/lib/sysctl.d/50-brave.conf -t %{buildroot}/usr/lib/sysctl.d/
+install -m 644 usr/lib/sysctl.d/53-brave.conf -t %{buildroot}/usr/lib/sysctl.d/
 
 mkdir -p %{buildroot}/etc/yum.repos.d
 
@@ -40,7 +40,7 @@ mkdir -p %{buildroot}/etc/yum.repos.d
 /etc/pki/rpm-gpg/RPM-GPG-KEY-brave-beta
 /etc/pki/rpm-gpg/RPM-GPG-KEY-brave-nightly
 /etc/cron.daily/brave-key-updater
-/usr/lib/sysctl.d/50-brave.conf
+/usr/lib/sysctl.d/53-brave.conf
 
 %post
 service atd start


### PR DESCRIPTION
Remove a deprecated Debian-specific option (https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html#linux-user-namespaces)

Rename the file to 53-brave.conf. In openSUSE, the uncommented option would be otherwise overriden by [/usr/lib/sysctl.d/52-yama.conf](https://github.com/openSUSE/aaa_base/blob/master/files/usr/lib/sysctl.d/52-yama.conf)