### PR TITLE
Handle apt sources format in keyring postinst.

### DIFF
--- a/deb/brave-keyring/DEBIAN/postinst
+++ b/deb/brave-keyring/DEBIAN/postinst
@@ -3,12 +3,16 @@
 [ "$1" = configure ] || exit
 
 # Match if the new keyring in /usr/share/keyrings is in use.
-new_keyring_pattern='^[[:space:]]*deb[^#]*signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg[^#]*brave-browser-apt-release.s3.brave.com'
+new_keyring_list_pattern='^[[:space:]]*deb[^#]*signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg[^#]*brave-browser-apt-release.s3.brave.com'
+new_keyring_sources_pattern='^Signed-By:[[:space:]]*/usr/share/keyrings/brave-browser-archive-keyring.gpg'
 
 # Delete the old keyring file if the new one is already in use.
 # Otherwise replace the old file with a symlink to its new location.
 if [ -f /etc/apt/sources.list.d/brave-browser-release.list ] &&\
-   grep -q "${new_keyring_pattern:?}" /etc/apt/sources.list.d/brave-browser-release.list; then
+   grep -q "${new_keyring_list_pattern:?}" /etc/apt/sources.list.d/brave-browser-release.list; then
+    rm -f /etc/apt/trusted.gpg.d/brave-browser-release.gpg
+elif [ -f /etc/apt/sources.list.d/brave-browser-release.sources ] &&\
+   grep -q "${new_keyring_sources_pattern:?}" /etc/apt/sources.list.d/brave-browser-release.sources; then
     rm -f /etc/apt/trusted.gpg.d/brave-browser-release.gpg
 else
     ln -sf /usr/share/keyrings/brave-browser-archive-keyring.gpg /etc/apt/trusted.gpg.d/brave-browser-release.gpg

--- a/deb/brave-keyring/DEBIAN/postinst
+++ b/deb/brave-keyring/DEBIAN/postinst
@@ -4,7 +4,7 @@
 
 # Match if the new keyring in /usr/share/keyrings is in use.
 new_keyring_list_pattern='^[[:space:]]*deb[^#]*signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg[^#]*brave-browser-apt-release.s3.brave.com'
-new_keyring_sources_pattern='^Signed-By:[[:space:]]*/usr/share/keyrings/brave-browser-archive-keyring.gpg'
+new_keyring_sources_pattern='^[Ss][Ii][Gg][Nn][Ee][Dd]-[Bb][Yy]:[[:space:]]*/usr/share/keyrings/brave-browser-archive-keyring.gpg'
 
 # Delete the old keyring file if the new one is already in use.
 # Otherwise replace the old file with a symlink to its new location.


### PR DESCRIPTION
This script checks whether the brave-browser-release.list file is using the new keyring location in /usr/share/keyrings and removes the symlink in /etc/apt/trusted.gpg.d if it is.  This doesn't handle the newer apt .sources format files that are now deployed by the install script and the website [manual instructions](https://brave.com/linux/#debian-ubuntu-mint), and therefore leaves an unnecessary symlink in `/etc/apt/trusted.gpg.d` meaning the brave keyring is trusted for all repositories on the system.

This therefore updates the script to also check for the newer .sources file and look for the Signed-By: line in there.